### PR TITLE
Scope sponsorships nonempty check to generateTable

### DIFF
--- a/src/main/twirl/sponsorshipExpiryEmailBody.scala.html
+++ b/src/main/twirl/sponsorshipExpiryEmailBody.scala.html
@@ -12,7 +12,7 @@
 }
 
 @generateTable(sponsorships: Seq[Sponsorship], noSponsorshipsMsg: String, validToLabel: String) = {
-@if(expiringSponsorships.nonEmpty) {
+@if(sponsorships.nonEmpty) {
     <table>
     @for(s <- sponsorships) {
         <tr>


### PR DESCRIPTION
## What does this change?

Reduces the scope of the `nonempty` empty check to within the `generateTable` function body. Previously, if there were no **expiring** sponsorships, the email would also say there are no **expired** sponsorships.

## How to test

Run the Lambda locally. I had to hardcode the recipients and sender as it was easier than retrieving them from environment variables.

You'll need to `Composer.Dev` permissions from Janus.

Observe the email shows the correct number of expiring and expired sponsorships.

## Before

<img width="606" alt="Screenshot 2022-10-31 at 12 20 50" src="https://user-images.githubusercontent.com/5931528/199007024-8894f380-2b2c-4679-8c0c-62af42601e78.png">

## After
<img width="667" alt="Screenshot 2022-10-31 at 12 20 43" src="https://user-images.githubusercontent.com/5931528/199007608-05e00c28-c56c-4b3c-8820-8d538bbc827a.png">


## How can we measure success?

I'm in contact with the Labs team who receive these emails. They were sad when this email stopped working due to DMARC issues, so I'm getting it up and running for them. This bug is unrelated to those issues, but I feel still needs fixing. They will let me know if this email sparks joy.
