### PR TITLE
Bump sbt and AWS SDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "sponsorship-expiry-email-lambda"
 
 enablePlugins(SbtTwirl, JavaAppPackaging, RiffRaffArtifact)
 
-val AwsSdkVersion = "1.11.269"
+val AwsSdkVersion = "1.12.329"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-lambda" % AwsSdkVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17


### PR DESCRIPTION
## What does this change?

Bumps versions of sbt and AWS SDK

AWS SDK 1.11 still works, but is [no longer supported](https://github.com/aws/aws-sdk-java#supported-minor-versions)

Before the sbt bump, I was getting:

```sh
$ sbt

java.lang.NullPointerException
	at java.base/java.util.regex.Matcher.getTextLength(Matcher.java:1770)
	at java.base/java.util.regex.Matcher.reset(Matcher.java:416)
	at java.base/java.util.regex.Matcher.<init>(Matcher.java:253)
	at java.base/java.util.regex.Pattern.matcher(Pattern.java:1133)
	at java.base/java.util.regex.Pattern.split(Pattern.java:1261)
	at java.base/java.util.regex.Pattern.split(Pattern.java:1334)
	at sbt.IO$.pathSplit(IO.scala:797)
	at sbt.IO$.parseClasspath(IO.scala:912)
	at sbt.compiler.CompilerArguments.extClasspath(CompilerArguments.scala:66)
	at sbt.compiler.MixedAnalyzingCompiler$.withBootclasspath(MixedAnalyzingCompiler.scala:188)
	at sbt.compiler.MixedAnalyzingCompiler$.searchClasspathAndLookup(MixedAnalyzingCompiler.scala:166)
	at sbt.compiler.MixedAnalyzingCompiler$.apply(MixedAnalyzingCompiler.scala:176)
	at sbt.compiler.IC$.incrementalCompile(IncrementalCompiler.scala:138)
	at sbt.Compiler$.compile(Compiler.scala:155)
	at sbt.Compiler$.compile(Compiler.scala:141)
	at sbt.Defaults$.sbt$Defaults$$compileIncrementalTaskImpl(Defaults.scala:879)
	at sbt.Defaults$$anonfun$compileIncrementalTask$1.apply(Defaults.scala:870)
	at sbt.Defaults$$anonfun$compileIncrementalTask$1.apply(Defaults.scala:868)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
[error] (compile:compileIncremental) java.lang.NullPointerException
```

## How can we measure success?

Up to date dependencies makes the lambda easier to run and work with.
