### PR TITLE
Riffraff: use bucketSsmLookup instead of bucket name

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     type: aws-lambda
     parameters:
       fileName: sponsorship-expiry-email-lambda.zip
-      bucket: sponsorship-expiry-email-lambda-dist
+      bucketSsmLookup: true
       functions:
         PROD:
           name: sponsorship-expiry-email-lambda-PROD


### PR DESCRIPTION
## What does this change?

Use `bucketSsmLookup` instead of bucket name 

See guardian/riff-raff#704

## How to test

Deploy this to PROD 🔥 Observe no warnings in RiffRaff

<img width="1208" alt="Screenshot 2022-10-31 at 15 04 47" src="https://user-images.githubusercontent.com/5931528/199040444-6e26ea0c-d74e-49f8-ac3d-7cd5cd896460.png">

