### PR TITLE
make validFrom an option[long]

### DIFF
--- a/src/main/scala/com/gu/comdev/sponsorshipexpiry/models/Sponsorship.scala
+++ b/src/main/scala/com/gu/comdev/sponsorshipexpiry/models/Sponsorship.scala
@@ -2,7 +2,7 @@ package com.gu.comdev.sponsorshipexpiry.models
 
 case class Sponsorship(
   id: Int,
-  validFrom: Long,
+  validFrom: Option[Long],
   validTo: Long,
   status: String,
   sponsorshipType: String,


### PR DESCRIPTION
## What does this change?

It's legit for the validFrom date to be missing from the sponsorship campaign data. Since we don't even use that field in this codebase, it's not even important.

However every time we run a query against the data and encounter a record with no validFrom date, this lambda logs an error. Using the correct type prevents this.

