### PR TITLE
Build with GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+    branches: ["main"]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   push:
-    branches: ["main"]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
         buildNumberOffset: 37 # This is the last build number from TeamCity
         contentDirectories: |
           sponsorship-expiry-email-lambda:
-          - sponsorship-expiry-email-lambda.zip
+          - target/scala*/sponsorship-expiry-email-lambda.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Test and build
       run: |
-        sbt clean compile test
+        sbt clean compile test universal:packageBin
 
     - name: Upload to riff-raff
       uses: guardian/actions-riff-raff@v2
@@ -36,4 +36,4 @@ jobs:
         buildNumberOffset: 37 # This is the last build number from TeamCity
         contentDirectories: |
           sponsorship-expiry-email-lambda:
-          - target/scala-2.12/sponsorship-expiry-email-lambda.zip
+          - target/universal/sponsorship-expiry-email-lambda.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
         buildNumberOffset: 37 # This is the last build number from TeamCity
         contentDirectories: |
           sponsorship-expiry-email-lambda:
-          - target/scala*/sponsorship-expiry-email-lambda.zip
+          - target/scala-2.12/sponsorship-expiry-email-lambda.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'corretto'
+        java-version: '8'
+        cache: 'sbt'
+    - name: test and build sbt
+        run: |
+          sbt clean compile test
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+        aws-region: eu-west-1
+    - uses: guardian/actions-riff-raff@v2
+        with:
+          configPath: riff-raff.yaml
+          projectName: Editorial Tools::sponsorship-expiry-email-lambda
+          buildNumberOffset: 37 # This is the last build number from TeamCity
+          contentDirectories: |
+            sponsorship-expiry-email-lambda:
+              - sponsorship-expiry-email-lambda.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,24 +10,30 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - uses: actions/setup-java@v3
       with:
         distribution: 'corretto'
         java-version: '8'
         cache: 'sbt'
-    - name: test and build sbt
-        run: |
-          sbt clean compile test
-    - uses: aws-actions/configure-aws-credentials@v1
+
+    - name: AWS Auth
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
         aws-region: eu-west-1
-    - uses: guardian/actions-riff-raff@v2
-        with:
-          configPath: riff-raff.yaml
-          projectName: Editorial Tools::sponsorship-expiry-email-lambda
-          buildNumberOffset: 37 # This is the last build number from TeamCity
-          contentDirectories: |
-            sponsorship-expiry-email-lambda:
-              - sponsorship-expiry-email-lambda.zip
+
+    - name: Test and build
+      run: |
+        sbt clean compile test
+
+    - name: Upload to riff-raff
+      uses: guardian/actions-riff-raff@v2
+      with:
+        configPath: riff-raff.yaml
+        projectName: Editorial Tools::sponsorship-expiry-email-lambda
+        buildNumberOffset: 37 # This is the last build number from TeamCity
+        contentDirectories: |
+          sponsorship-expiry-email-lambda:
+          - sponsorship-expiry-email-lambda.zip

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ scalaVersion  := "2.12.4"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
 name := "sponsorship-expiry-email-lambda"
 
-enablePlugins(SbtTwirl, JavaAppPackaging, RiffRaffArtifact)
+enablePlugins(SbtTwirl, JavaAppPackaging)
 
 val AwsSdkVersion = "1.12.329"
 
@@ -18,12 +18,6 @@ libraryDependencies ++= Seq(
 
  topLevelDirectory in Universal := None
  packageName in Universal := normalizedName.value
-
- riffRaffManifestProjectName := s"Editorial Tools::${name.value}"
- riffRaffPackageName := "sponsorship-expiry-email-lambda"
- riffRaffPackageType := (packageBin in Universal).value
- riffRaffUploadArtifactBucket := Option("riffraff-artifact")
- riffRaffUploadManifestBucket := Option("riffraff-builds")
 
 TwirlKeys.templateImports += "com.gu.comdev.sponsorshipexpiry.models._"
 TwirlKeys.templateImports += "org.joda.time.format.DateTimeFormat"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,6 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.13")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")


### PR DESCRIPTION
## What does this change?
Adds a `build.yml` file to build the project on push to main.

The build in TeamCity has now been paused, as we're migrating away from it.

Also deletes the `sbt-riffraff-artifact` plugin, as we've migrated to using the riffraff action in our `build.yml` instead.

The build action has been tested, and successfully deployed via Riff Raff.
