### PR TITLE
Upgrade to guardian/actions-riff-raff@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      pull-requests: write
       contents: read
     steps:
     - uses: actions/checkout@v3
@@ -29,8 +30,9 @@ jobs:
         sbt clean compile test universal:packageBin
 
     - name: Upload to riff-raff
-      uses: guardian/actions-riff-raff@v2
+      uses: guardian/actions-riff-raff@v3
       with:
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
         configPath: riff-raff.yaml
         projectName: Editorial Tools::sponsorship-expiry-email-lambda
         buildNumberOffset: 37 # This is the last build number from TeamCity

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,20 +19,15 @@ jobs:
         java-version: '8'
         cache: 'sbt'
 
-    - name: AWS Auth
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-        aws-region: eu-west-1
-
     - name: Test and build
       run: |
         sbt clean compile test universal:packageBin
 
     - name: Upload to riff-raff
-      uses: guardian/actions-riff-raff@v3
+      uses: guardian/actions-riff-raff@v4
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
+        roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
         configPath: riff-raff.yaml
         projectName: Editorial Tools::sponsorship-expiry-email-lambda
         buildNumberOffset: 37 # This is the last build number from TeamCity


### PR DESCRIPTION
## What does this change?
Updates the project to build using `guardian/actions-riff-raff@v4`. This is being done following a recommendation from DevX, as this newer version of `guardian/actions-riff-raff` includes security improvements.