### PR TITLE
Fix Scala Steward by using Java 11 (also newer sbt)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'corretto'
-        java-version: '8'
+        java-version: '11'
         cache: 'sbt'
 
     - name: Test and build

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,6 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian
       SKIP_NODE: true
-      JAVA_VERSION: 8
+      JAVA_VERSION: 11
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ project/project
 logs/
 project/target
 target
+.bsp/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.17.8.1

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization  := "com.gu"
 description   := "AWS Lambda to send email to stakeholders for expired sponsorships."
-scalaVersion  := "2.12.4"
+scalaVersion  := "2.12.19"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
 name := "sponsorship-expiry-email-lambda"
 
@@ -16,8 +16,8 @@ libraryDependencies ++= Seq(
   "com.gu" %% "scanamo" % "1.0.0-M4"
 )
 
- topLevelDirectory in Universal := None
- packageName in Universal := normalizedName.value
+Universal / topLevelDirectory := None
+Universal / packageName := normalizedName.value
 
 dependencyOverrides += "org.jetbrains.kotlin" % "kotlin-stdlib" % "[1.6.0,)"
 
@@ -27,6 +27,6 @@ TwirlKeys.templateImports += "org.joda.time.DateTime"
 
 initialize := {
   val _ = initialize.value
-  assert(sys.props("java.specification.version") == "1.8",
-    "Java 8 is required for this project.")
+  assert(sys.props("java.specification.version").toInt >= 11,
+    "Java 11 is required for this project.")
 }

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -83,7 +83,7 @@ Resources:
       Handler : com.gu.comdev.sponsorshipexpiry.Lambda::handleRequest
       MemorySize : 512
       Role: !GetAtt SponsorshipExpiryEmailLambdaRole.Arn
-      Runtime : java8
+      Runtime : java11
       Timeout : 180
       VpcConfig:
         SecurityGroupIds: [ !Ref SponsorshipExpiryEmailLambdaSecurityGroup ]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,24 @@
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-releases/"
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.0.4")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.13")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addDependencyTreePlugin
 
+/*
+   Without setting VersionScheme.Always here on `scala-xml`, sbt 1.8.0 will raise fatal 'version conflict' errors when
+   used with sbt plugins like `sbt-native-packager`, which currently use sort-of-incompatible versions of the `scala-xml`
+   library. sbt 1.8.0 has upgraded to Scala 2.12.18, which has itself upgraded to `scala-xml` 2.1.0
+   (see https://github.com/sbt/sbt/releases/tag/v1.8.0), but `sbt-native-packager` is currently using `scala-xml` 1.1.1,
+    and the `scala-xml` library declares that it uses specifically 'early-semver' version compatibility (see
+    https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#versionscheme-librarydependencyschemes-and-sbt-150 ),
+    meaning that for version x.y.z, `x` & `y` *must match exactly* for versions to be considered compatible by sbt.
+
+    By setting VersionScheme.Always here on `scala-xml`, we're overriding its declared version-compatability scheme,
+    choosing to tolerate the risk of binary incompatibility. We consider this a safe operation because when set under
+    `projects/` (ie *not* in `build.sbt` itself) it only affects the compilation of build.sbt, not of the application
+    build itself. Once the build has succeeded, there is no further risk (ie of a runtime exception due to clashing
+    versions of `scala-xml`).
+ */
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
The `sponsorship-expiry-email-lambda` has some code in its `build.sbt` that requires Java 8;

https://github.com/guardian/sponsorship-expiry-email-lambda/blob/6b7c1bd0da3eeaa3e75a4efd5ac706968fa6d4df/build.sbt#L28-L32

...but it was recently added to our Scala Steward run ([see how to do that here](https://github.com/guardian/scala-steward-public-repos?tab=readme-ov-file#how-to-add-a-new-public-repo-for-scanning-by-scala-steward)) and as Scala Steward is running using Java 11, this new repo was causing the Scala Steward run to [fail](https://github.com/guardian/scala-steward-public-repos/actions/runs/8064282983/job/22027855642#step:5:1753):

![image](https://github.com/guardian/sponsorship-expiry-email-lambda/assets/52038/3fa3a7b9-c504-4102-9407-7b2e39078f1a)

> java.lang.AssertionError: assertion failed: Java 8 is required for this project.

...that's bad, especially for the reason described in https://github.com/guardian/scala-steward-public-repos/issues/60.

This change updates guardian/sponsorship-expiry-email-lambda to use Java 11, and also updates sbt to the latest version to make it run on our modern M1 laptops.

@emma-imber, as a recent contributor to this repo, you probably have a good idea of how to check that lambda isn't broken! If you'd like a walkthough of the changes I've made here, I be very happy to take you through them?
