### PR TITLE
Pin version of aws-java-sdk-s3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-lambda" % AwsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % AwsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % AwsSdkVersion,
+  "com.amazonaws" % "aws-java-sdk-s3" % AwsSdkVersion,
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.gu" %% "scanamo" % "1.0.0-M4"
 )


### PR DESCRIPTION
## What does this change?
Pins the version of `aws-java-sdk-s3` that we use to resolve a vulnerability.
